### PR TITLE
Display a label when no torrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,30 @@
 This Lovelace custom card displays torrents information provided by the Transmission Integration.
 It also supports turtle mode and start/stop of all torrents.
 
-#### Installation
+### Installation
+
 The easiest way to install it is through [HACS (Home Assistant Community Store)](https://custom-components.github.io/hacs/),
-search for <i>Transmission</i> in the Frontend section and select Transmission Card.<br />
+search for *Transmission* in the Frontend section and select Transmission Card.<br />
 If you are not using HACS, you may download transmission-card.js and put it into
 homeassistant_config_dir/www/community/transmission-card/ directory.<br />
 
-#### Lovelace UI configuration
+### Lovelace UI configuration
+
 Please add the card to the resources in configuration.yaml:
 
 ```
 resources:
   - {type: js, url: '/hacsfiles/transmission-card/transmission-card.js'}
 ```
+
+### Options
+
+#### Card options
+
+| Name             | Type         | Required     | Default                 | Description                         |
+| ---------------- | ------------ | ------------ | ----------------------- | ----------------------------------- |
+| type             | string       | **required** |                         | `custom:logbook-card`               |
+| no_torrent_label | string       | optional     | 'No Torrents'           | label displayed with no torrents    |
 
 Please find below an example of ui-lovelace.yaml card entry:
 
@@ -29,5 +40,6 @@ Please find below an example of ui-lovelace.yaml card entry:
       - type: custom:transmission-card
 ```
 
-Transmission idle:<br />
+Transmission idle:
+
 ![Transmission idle](https://raw.githubusercontent.com/amaximus/transmission-card/main/transmission_idle.jpg)

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -53,7 +53,14 @@ class TransmissionCard extends HTMLElement {
     const root = this.shadowRoot;
     if (root.lastChild) root.removeChild(root.lastChild);
 
-    const cardConfig = Object.assign({}, config);
+    const defaultConfig = {
+      'no_torrent_label' : 'No torrents'
+    }
+
+    this._config = {
+      ...defaultConfig,
+      ...config
+    };
 
     const card = document.createElement('ha-card');
     card.setAttribute('header', 'Transmission');
@@ -146,6 +153,9 @@ table {
 .start_off {
   color: var(--primary-color);
 }
+.no-torrent {
+  margin-left: 1.4em;
+}
     `;
     content.innerHTML = `
       <table id='title'></table>
@@ -154,11 +164,11 @@ table {
     card.appendChild(style);
     card.appendChild(content);
     root.appendChild(card)
-    this._config = cardConfig;
   }
 
   _updateContent(element, torrents) {
-    element.innerHTML = `
+    if (torrents.length > 0) {
+      element.innerHTML = `
       ${torrents.map((torrent) => `
         <div class="progressbar">
           <div class="${torrent.state} progressin" style="width:${torrent.percent}%">
@@ -168,6 +178,10 @@ table {
         </div>
       `).join('')}
     `;
+    } 
+    else {
+      element.innerHTML = `<div class="no-torrent">${this._config.no_torrent_label}</div>`;
+    }
   }
 
   _updateTitle(element, gattributes) {


### PR DESCRIPTION
Add a label when no torrents

![image](https://user-images.githubusercontent.com/6990995/100370737-031bf400-3007-11eb-8fb8-b23390b85da6.png)

Label is configurable using a config option 

example with a french label
```
type: 'custom:transmission-card'
no_torrent_label: Aucun torrent
```

![image](https://user-images.githubusercontent.com/6990995/100370871-3cecfa80-3007-11eb-9849-0e9e68ae8cbd.png)
 