### PR TITLE
Add "header_text" and "hide_header" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ resources:
 | default_type     | string       | optional     | `total`                 | type of torrents to display at start |
 | display_mode     | string       | optional     | `compact`               | display mode: compact or full       |
 | sensor_name      | string       | optional     | `transmission`          | name of the sensor                  |
+| hide_header      | boolean      | optional     | false                   | hide header text at the top of card |
+| header_text      | string       | optional     | `Transmission`          | header text at the top of card      |
 
 Accepted values for default_type are: `total`, `active`,`completed`,`paused`,`started`.
 

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -113,7 +113,7 @@ class TransmissionCard extends LitElement {
 
     const torrents = this._getTorrents(this.hass, this.selectedType, this.config.sensor_name);
     return html`
-      <ha-card header=${this.config.header_text}>
+      <ha-card>
         <div>
           <div id="title">
               ${this.renderTitle()}

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -131,11 +131,6 @@ class TransmissionCard extends LitElement {
           }
           </div>
         </div>
-        <script>
-          function Geeks() {
-            $("#header").hide();
-        } 
-    </script>
       </ha-card>
     `;
   }
@@ -280,9 +275,6 @@ class TransmissionCard extends LitElement {
       position: relative;
       margin-left: 1.4em;
       margin-right: 1.4em;
-    }
-    .header {
-      display: none;
     }
     .progressin {
       border-radius: 0.4em;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -275,6 +275,9 @@ class TransmissionCard extends LitElement {
       margin-left: 1.4em;
       margin-right: 1.4em;
     }
+    .header {
+      display: none;
+    }
     .progressin {
       border-radius: 0.4em;
       height: 100%;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -96,6 +96,7 @@ class TransmissionCard extends LitElement {
       'default_type': 'total',
       'display_mode': 'compact',
       'sensor_name': 'transmission',
+      'header_text': 'Transmission',
     }
 
     this.config = {
@@ -130,6 +131,11 @@ class TransmissionCard extends LitElement {
           }
           </div>
         </div>
+        <script>
+          function Geeks() {
+            $("#header").hide();
+        } 
+    </script>
       </ha-card>
     `;
   }

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -113,7 +113,7 @@ class TransmissionCard extends LitElement {
 
     const torrents = this._getTorrents(this.hass, this.selectedType, this.config.sensor_name);
     return html`
-      <ha-card header="Test">
+      <ha-card header=${this.config.header_text}>
         <div>
           <div id="title">
               ${this.renderTitle()}

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -235,10 +235,13 @@ class TransmissionCard extends LitElement {
   
   renderCardHeader() {
     if (this.config.header) {
-      return html`
-        <div class="h-name">
-          ${this.config.header_text}
-        </div>
+      return html``;
+    }
+    
+    return html`
+      <div class="h-name">
+        ${this.config.header_text}
+      </div>
     `;
   }
 

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -118,7 +118,6 @@ class TransmissionCard extends LitElement {
       <ha-card>
         <div class="card-header">
           ${this.renderCardHeader1()}
-          ${this.renderCardHeader2()}
         </div>
         <div>
           <div id="title">
@@ -236,7 +235,7 @@ class TransmissionCard extends LitElement {
   }
   
   renderCardHeader1() {
-    if (this.config.hide_header == true) {
+    if (this.config.hide_header) {
       return html``;
     }
     

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -116,7 +116,7 @@ class TransmissionCard extends LitElement {
     return html`
       <ha-card>
         <div class="card-header">
-          <div class="name">
+          <div class="h-name">
             ${this.config.header_text}
           </div>
         </div>
@@ -307,6 +307,9 @@ class TransmissionCard extends LitElement {
       background-color: var(--paper-item-icon-active-color);
     }
     .card-header {
+      display: none;
+    }
+    .h-name {
       display: none;
     }
     .c-Downloading, .c-UpDown {

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -241,7 +241,7 @@ class TransmissionCard extends LitElement {
     }
     
     return html`
-      <div class="h-name">
+      <div class="v-name">
         ${this.config.header_text}
       </div>
     `;
@@ -253,7 +253,7 @@ class TransmissionCard extends LitElement {
     }
     
     return html`
-      <div class="v-name">
+      <div class="h-name">
         ${this.config.header_text}
       </div>
     `;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -97,6 +97,7 @@ class TransmissionCard extends LitElement {
       'display_mode': 'compact',
       'sensor_name': 'transmission',
       'header_text': 'Transmission',
+      'hide_header': false,
     }
 
     this.config = {
@@ -116,7 +117,8 @@ class TransmissionCard extends LitElement {
     return html`
       <ha-card>
         <div class="card-header">
-          ${this.renderCardHeader()}
+          ${this.renderCardHeader1()}
+          ${this.renderCardHeader2()}
         </div>
         <div>
           <div id="title">
@@ -233,13 +235,25 @@ class TransmissionCard extends LitElement {
     `;
   }
   
-  renderCardHeader() {
-    if (this.config.header) {
+  renderCardHeader1() {
+    if (this.config.hide_header) {
       return html``;
     }
     
     return html`
       <div class="h-name">
+        ${this.config.header_text}
+      </div>
+    `;
+  }
+
+  renderCardHeader2() {
+    if (!this.config.hide_header) {
+      return html``;
+    }
+    
+    return html`
+      <div class="v-name">
         ${this.config.header_text}
       </div>
     `;
@@ -315,9 +329,6 @@ class TransmissionCard extends LitElement {
     }
     .downloading {
       background-color: var(--paper-item-icon-active-color);
-    }
-    .card-header {
-      display: none;
     }
     .h-name {
       display: none;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -97,7 +97,7 @@ class TransmissionCard extends LitElement {
       'display_mode': 'compact',
       'sensor_name': 'transmission',
       'header_text': 'Transmission',
-      'hide_header': false,
+      'header': true,
     }
 
     this.config = {
@@ -118,6 +118,7 @@ class TransmissionCard extends LitElement {
       <ha-card>
         <div class="card-header">
           ${this.renderCardHeader1()}
+          ${this.renderCardHeader2()}
         </div>
         <div>
           <div id="title">
@@ -235,7 +236,7 @@ class TransmissionCard extends LitElement {
   }
   
   renderCardHeader1() {
-    if (this.config.hide_header) {
+    if (this.config.header) {
       return html``;
     }
     
@@ -247,12 +248,12 @@ class TransmissionCard extends LitElement {
   }
 
   renderCardHeader2() {
-    if (this.config.hide_header == false) {
+    if (!this.config.header) {
       return html``;
     }
     
     return html`
-      <div class="v-name">
+      <div class="h-name">
         ${this.config.header_text}
       </div>
     `;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -236,24 +236,24 @@ class TransmissionCard extends LitElement {
   }
   
   renderCardHeader1() {
-    if (this.config.hide_header) {
+    if (this.config.hide_header == true) {
       return html``;
     }
     
     return html`
-      <div class="v-name">
+      <div class="h-name">
         ${this.config.header_text}
       </div>
     `;
   }
 
   renderCardHeader2() {
-    if (!this.config.hide_header) {
+    if (this.config.hide_header == false) {
       return html``;
     }
     
     return html`
-      <div class="h-name">
+      <div class="v-name">
         ${this.config.header_text}
       </div>
     `;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -113,7 +113,7 @@ class TransmissionCard extends LitElement {
 
     const torrents = this._getTorrents(this.hass, this.selectedType, this.config.sensor_name);
     return html`
-      <ha-card header="Transmission">
+      <ha-card header="Test">
         <div>
           <div id="title">
               ${this.renderTitle()}

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -240,7 +240,7 @@ class TransmissionCard extends LitElement {
     }
     
     return html`
-      <div class="h-name">
+      <div class="v-name">
         ${this.config.header_text}
       </div>
     `;

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -116,9 +116,7 @@ class TransmissionCard extends LitElement {
     return html`
       <ha-card>
         <div class="card-header">
-          <div class="h-name">
-            ${this.config.header_text}
-          </div>
+          ${this.renderCardHeader()}
         </div>
         <div>
           <div id="title">
@@ -232,6 +230,15 @@ class TransmissionCard extends LitElement {
           id="start">
         </ha-icon-button>
       </div>
+    `;
+  }
+  
+  renderCardHeader() {
+    if (this.config.header) {
+      return html`
+          <div class="h-name">
+            ${this.config.header_text}
+          </div>
     `;
   }
 

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -306,6 +306,9 @@ class TransmissionCard extends LitElement {
     .downloading {
       background-color: var(--paper-item-icon-active-color);
     }
+    .card-header {
+      display: none;
+    }
     .c-Downloading, .c-UpDown {
       color: var(--paper-item-icon-active-color);
     }

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -113,7 +113,7 @@ class TransmissionCard extends LitElement {
 
     const torrents = this._getTorrents(this.hass, this.selectedType, this.config.sensor_name);
     return html`
-      <ha-card>
+      <ha-card header=${this.config.header_text}>
         <div>
           <div id="title">
               ${this.renderTitle()}

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -97,7 +97,7 @@ class TransmissionCard extends LitElement {
       'display_mode': 'compact',
       'sensor_name': 'transmission',
       'header_text': 'Transmission',
-      'header': true,
+      'hide_header': false,
     }
 
     this.config = {
@@ -236,7 +236,7 @@ class TransmissionCard extends LitElement {
   }
   
   renderCardHeader1() {
-    if (this.config.header) {
+    if (this.config.hide_header) {
       return html``;
     }
     
@@ -248,7 +248,7 @@ class TransmissionCard extends LitElement {
   }
 
   renderCardHeader2() {
-    if (!this.config.header) {
+    if (!this.config.hide_header) {
       return html``;
     }
     

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -114,7 +114,12 @@ class TransmissionCard extends LitElement {
 
     const torrents = this._getTorrents(this.hass, this.selectedType, this.config.sensor_name);
     return html`
-      <ha-card header=${this.config.header_text}>
+      <ha-card>
+        <div class="card-header">
+          <div class="name">
+            ${this.config.header_text}
+          </div>
+        </div>
         <div>
           <div id="title">
               ${this.renderTitle()}

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -236,9 +236,9 @@ class TransmissionCard extends LitElement {
   renderCardHeader() {
     if (this.config.header) {
       return html`
-          <div class="h-name">
-            ${this.config.header_text}
-          </div>
+        <div class="h-name">
+          ${this.config.header_text}
+        </div>
     `;
   }
 


### PR DESCRIPTION
This pull request adds two customization options to the header text at the top of the card. By default the header reads "Transmission".

- **"header_text"** accepts any text string and allows the use of custom text for the header. The default text is "Transmission".
- **"hide_header"** is a boolean option. Setting it to true will hide the header text entirely. The default is "false", meaning that by default the header text will not be hidden. 

EDIT: Sorry about the over-abundance of commits. I went back and forth quite a bit before I got it where I wanted it. Overall code changes in the end was fairly minimal.