### PR TITLE
Update transmission-card.js

### DIFF
--- a/transmission-card.js
+++ b/transmission-card.js
@@ -422,7 +422,9 @@ class TransmissionCard extends LitElement {
   }
 }
 
-customElements.define('transmission-card', TransmissionCard);
+if (!customElements.get('transmission-card')) {
+  customElements.define('transmission-card', TransmissionCard);
+}
 
 // Puts card into the UI card picker dialog
 (window).customCards = (window).customCards || [];


### PR DESCRIPTION
I am not a JS developer, but this is to fix 
`Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "transmission-card" has already been used with this registry
    at http://localhost/hacsfiles/transmission-card/transmission-card.js:425:16`