### PR TITLE
use entity precision to format download and upload speed

### DIFF
--- a/transmission-card.js
+++ b/transmission-card.js
@@ -55,9 +55,9 @@ class TransmissionCard extends LitElement {
 
     if (typeof this.hass.states[`sensor.${sensor_entity_id}_down_speed`] != "undefined") {
       return {
-        down_speed: Math.round(this.hass.states[`sensor.${sensor_entity_id}_down_speed`].state * 10) / 10,
+        down_speed: this._formatSpeed(this.hass, `sensor.${sensor_entity_id}_down_speed`),
         down_unit: this.hass.states[`sensor.${sensor_entity_id}_down_speed`].attributes['unit_of_measurement'],
-        up_speed: Math.round(this.hass.states[`sensor.${sensor_entity_id}_up_speed`].state * 10) / 10,
+        up_speed: this._formatSpeed(this.hass, `sensor.${sensor_entity_id}_up_speed`),
         up_unit: this.hass.states[`sensor.${sensor_entity_id}_up_speed`].attributes['unit_of_measurement'],
         status: this.hass.states[`sensor.${sensor_entity_id}_status`].state
       }
@@ -69,6 +69,20 @@ class TransmissionCard extends LitElement {
       up_unit: "MB/s",
       status: "no sensor"
     };
+  }
+
+  _formatSpeed(hass, speedSensor) {
+    const precision = this.hass.entities[speedSensor].display_precision;
+    if (Intl) {
+      return Intl.NumberFormat(
+        hass.locale.language, 
+        { 
+          minimumFractionDigits: precision,
+          maximumFractionDigits: precision
+        }).format(this.hass.states[speedSensor].state);
+    }
+
+    return parseFloat(this.hass.states[speedSensor].state).toFixed(precision);
   }
 
   _toggleTurtle() {


### PR DESCRIPTION
Hello, 

a quick Pull request to handle entity precision for speeds. 
HA has introduced the ability to set precision per entities. Here I have set the precision of dowload speed to `0.0` (default precision is `0.00` meaning 2 decimals)

![image](https://github.com/amaximus/transmission-card/assets/6990995/9ad49b28-c111-46db-976c-818446ea0904)

You can see that download is displayed with 1 decimal and not upload speed that use default precision.

![image](https://github.com/amaximus/transmission-card/assets/6990995/f8ebac9b-f2ea-41dd-a217-5181b87783e7)

This allows to have consistent display between the card and HA.

![image](https://github.com/amaximus/transmission-card/assets/6990995/697b6174-8699-4042-b4ee-a196aa1a6042)


