### PR TITLE
Add ratio of each torrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ resources:
 | hide_order               | boolean      | optional     | true                    | hide sort selector |
 | default_limit            | string       | optional     | `all`                   | limit number of torrents to display at start |
 | hide_limit               | boolean      | optional     | true                    | hide limit selector |
+| hide_ratio               | boolean      | optional     | false                   | hide torrent ratio |
 
 Accepted values for default_type are: `total`, `active`,`completed`,`paused`,`started`.
 

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -36,7 +36,8 @@ const translations = {
     "start": "Start",
     "stop": "Stop",
     "delete": "Delete torrent",
-    "delete_data": "Delete torrent and data"
+    "delete_data": "Delete torrent and data",
+    "ratio": "Ratio"
   },
   "pt-BR": {
     "sensor_state": {
@@ -69,7 +70,8 @@ const translations = {
     "start": "Iniciar",
     "stop": "Parar",
     "delete": "Remover torrent",
-    "delete_data": "Remover torrent e arquivos"
+    "delete_data": "Remover torrent e arquivos",
+    "ratio": "Proporção"
   },
   "ru": {
     "sensor_state": {
@@ -179,6 +181,7 @@ class TransmissionCard extends LitElement {
           status: data1[key].status,
           added_date: data1[key].added_date,
           eta: data1[key].eta,
+          ratio: data1[key].ratio
         });
       });
     }
@@ -463,7 +466,10 @@ class TransmissionCard extends LitElement {
         <div class="${torrent.status} progressin" style="width:${torrent.percent}%">
         </div>
       </div>
-      <div class="torrent_details">${torrent.percent} %</div>
+      <div class="torrent_details">
+        ${torrent.percent} %
+        ${this.config.hide_ratio ? '' : ` - ${translations[this.hass.config.language]?.ratio || translations['en'].ratio}: ${torrent.ratio.toFixed(2)}`}
+      </div>
       <div class="torrent-buttons">
         ${this.renderTorrentButton(torrent)}
         ${this.renderTorrentDeleteButton(torrent, false)}


### PR DESCRIPTION
Since HA 2025.5, transmission integration provides ratio information about each torrent (https://github.com/home-assistant/core/pull/143459).

Fix #4 