### PR TITLE
Show ETA and customize color and additional hide options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ resources:
 | default_limit            | string       | optional     | `all`                   | limit number of torrents to display at start |
 | hide_limit               | boolean      | optional     | true                    | hide limit selector |
 | hide_ratio               | boolean      | optional     | false                   | hide torrent ratio |
+| hide_eta                 | boolean      | optional     | false                   | hide ETA (estimated time of arrival) |
+| hide_header_eta          | boolean      | optional     | false                   | hide label |
+| hide_seeding             | boolean      | optional     | false                   | hide seeding torrents from active list |
+| custom_colors            | object       | optional     | null                    | custom colors for torrent states (see below) |
+
+#### Custom Colors
+
+You can customize the progress bar colors for different torrent states:
+
+```yaml
+custom_colors:
+  downloading: '#00ff00'  # Color for downloading torrents
+  seeding: '#0000ff'      # Color for seeding torrents
+  stopped: '#ff0000'      # Color for stopped torrents
+```
 
 Accepted values for default_type are: `total`, `active`,`completed`,`paused`,`started`.
 
@@ -75,6 +90,11 @@ Please find below an example of ui-lovelace.yaml card entry:
       - type: custom:transmission-card
         hide_type: false
         default_type: 'active'
+        hide_eta: false
+        hide_header_eta: true
+        custom_colors:
+          downloading: '#2196F3'
+          seeding: '#4CAF50'
 ```
 
 Transmission idle in compact mode:

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -417,6 +417,7 @@ class TransmissionCard extends LitElement {
       'force_status_newline': false,
       'hide_seeding': false,
       'hide_eta': false,
+      'hide_header_eta': false,
       'hide_ratio': false,
       'custom_colors': {
         'downloading': null,
@@ -529,15 +530,14 @@ class TransmissionCard extends LitElement {
   renderTorrent(torrent) {
     const customColor = this._getCustomColor(torrent.status);
     const colorStyle = customColor ? `background-color: ${customColor};` : '';
+    const etaLabel = this.config.hide_header_eta ? '' : `${translations[this.hass.config.language]?.eta || translations['en'].eta}: `;
     
     return html`
       <div class="progressbar">
         <div class="${torrent.status} progressin" style="width:${torrent.percent}%; ${colorStyle}"></div>
         <div class="name">${torrent.name}</div>
-        <div class="percent">
-          ${torrent.percent}%
-          ${this.config.hide_eta || !torrent.eta || torrent.eta < 0 ? '' : ` - ${translations[this.hass.config.language]?.eta || translations['en'].eta}: ${this._formatEta(torrent.eta)}`}
-        </div>
+        ${this.config.hide_eta || !torrent.eta || torrent.eta < 0 ? '' : html`<div class="eta">${etaLabel}${this._formatEta(torrent.eta)}</div>`}
+        <div class="percent">${torrent.percent}%</div>
       </div>
     `;
   }
@@ -557,7 +557,7 @@ class TransmissionCard extends LitElement {
       <div class="torrent_details">
         ${torrent.percent} %
         ${this.config.hide_ratio ? '' : ` - ${translations[this.hass.config.language]?.ratio || translations['en'].ratio}: ${torrent.ratio.toFixed(2)}`}
-        ${this.config.hide_eta || !torrent.eta || torrent.eta < 0 ? '' : ` - ${translations[this.hass.config.language]?.eta || translations['en'].eta}: ${this._formatEta(torrent.eta)}`}
+        ${this.config.hide_eta || !torrent.eta || torrent.eta < 0 ? '' : ` - ${this.config.hide_header_eta ? '' : `${translations[this.hass.config.language]?.eta || translations['en'].eta}: `}${this._formatEta(torrent.eta)}`}
       </div>
       <div class="torrent-buttons">
         ${this.renderTorrentButton(torrent)}
@@ -849,19 +849,30 @@ class TransmissionCard extends LitElement {
     }
     .name {
       margin-left: 0.7em;
-      width: calc(100% - 60px);
       overflow: hidden;
       z-index: 2;
       color: var(--text-light-primary-color, var(--primary-text-color));
       line-height: 1.4em;
+      flex-shrink: 1;
+    }
+    .eta {
+      z-index: 2;
+      margin-left: 0.7em;
+      margin-right: 0.7em;
+      color: var(--text-light-primary-color, var(--primary-text-color));
+      line-height: 1.4em;
+      white-space: nowrap;
+      flex-shrink: 0;
     }
     .percent {
       vertical-align: middle;
       z-index: 2;
-      margin-left: 1.7em;
+      margin-left: auto;
       margin-right: 0.7em;
       color: var(--text-light-primary-color, var(--primary-text-color));
       line-height: 1.4em;
+      white-space: nowrap;
+      flex-shrink: 0;
     }
     .downloading {
       background-color: var(--accent-color);

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -534,7 +534,10 @@ class TransmissionCard extends LitElement {
       <div class="progressbar">
         <div class="${torrent.status} progressin" style="width:${torrent.percent}%; ${colorStyle}"></div>
         <div class="name">${torrent.name}</div>
-        <div class="percent">${torrent.percent}%</div>
+        <div class="percent">
+          ${torrent.percent}%
+          ${this.config.hide_eta || !torrent.eta || torrent.eta < 0 ? '' : ` - ${translations[this.hass.config.language]?.eta || translations['en'].eta}: ${this._formatEta(torrent.eta)}`}
+        </div>
       </div>
     `;
   }

--- a/transmission-card.js
+++ b/transmission-card.js
@@ -37,7 +37,8 @@ const translations = {
     "stop": "Stop",
     "delete": "Delete torrent",
     "delete_data": "Delete torrent and data",
-    "ratio": "Ratio"
+    "ratio": "Ratio",
+    "eta": "ETA"
   },
   "pt-BR": {
     "sensor_state": {
@@ -71,7 +72,8 @@ const translations = {
     "stop": "Parar",
     "delete": "Remover torrent",
     "delete_data": "Remover torrent e arquivos",
-    "ratio": "Proporção"
+    "ratio": "Proporção",
+    "eta": "ETA"
   },
   "ru": {
     "sensor_state": {
@@ -106,7 +108,8 @@ const translations = {
     "stop": "Остановить",
     "delete": "Удалить торрент",
     "delete_data": "Удалить торрент и данные",
-    "ratio": "соотношение"
+    "ratio": "соотношение",
+    "eta": "ETA"
   }
 }
 
@@ -212,6 +215,12 @@ class TransmissionCard extends LitElement {
         });
       });
     }
+    
+    // Filter seeding torrents if hide_seeding is enabled and type is 'active'
+    if (this.config.hide_seeding && type === 'active') {
+      res = res.filter(torrent => torrent.status !== 'seeding');
+    }
+    
     if ( limit != "all" ) {
       return sortDataBy(res, sort, order).slice(0, parseInt(limit));
     }
@@ -251,6 +260,41 @@ class TransmissionCard extends LitElement {
     }
 
     return parseFloat(this.hass.states[speedSensor].state).toFixed(precision);
+  }
+
+  _formatEta(seconds) {
+    if (seconds < 0) {
+      return 'Unknown';
+    }
+    
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    } else if (minutes > 0) {
+      return `${minutes}m`;
+    } else {
+      return `${seconds}s`;
+    }
+  }
+  
+  _getCustomColor(status) {
+    if (!this.config.custom_colors) {
+      return null;
+    }
+    
+    if (status === 'downloading' && this.config.custom_colors.downloading) {
+      return this.config.custom_colors.downloading;
+    }
+    if (status === 'seeding' && this.config.custom_colors.seeding) {
+      return this.config.custom_colors.seeding;
+    }
+    if (status === 'stopped' && this.config.custom_colors.stopped) {
+      return this.config.custom_colors.stopped;
+    }
+    
+    return null;
   }
 
   _toggleTurtle() {
@@ -371,6 +415,14 @@ class TransmissionCard extends LitElement {
       'hide_download_speed': false,
       'hide_status': false,
       'force_status_newline': false,
+      'hide_seeding': false,
+      'hide_eta': false,
+      'hide_ratio': false,
+      'custom_colors': {
+        'downloading': null,
+        'seeding': null,
+        'stopped': null
+      }
     }
 
     this.config = {
@@ -475,9 +527,12 @@ class TransmissionCard extends LitElement {
   }
 
   renderTorrent(torrent) {
+    const customColor = this._getCustomColor(torrent.status);
+    const colorStyle = customColor ? `background-color: ${customColor};` : '';
+    
     return html`
       <div class="progressbar">
-        <div class="${torrent.status} progressin" style="width:${torrent.percent}%"></div>
+        <div class="${torrent.status} progressin" style="width:${torrent.percent}%; ${colorStyle}"></div>
         <div class="name">${torrent.name}</div>
         <div class="percent">${torrent.percent}%</div>
       </div>
@@ -485,17 +540,21 @@ class TransmissionCard extends LitElement {
   }
 
   renderTorrentFull(torrent) {
+    const customColor = this._getCustomColor(torrent.status);
+    const colorStyle = customColor ? `background-color: ${customColor};` : '';
+    
     return html`
     <div class="torrent">
       <div class="torrent_name">${torrent.name}</div>
       <div class="torrent_state">${translations[this.hass.config.language]?.torrent_state[torrent.status] || translations['en'].torrent_state[torrent.status] || torrent.status}</div>
       <div class="progressbar">
-        <div class="${torrent.status} progressin" style="width:${torrent.percent}%">
+        <div class="${torrent.status} progressin" style="width:${torrent.percent}%; ${colorStyle}">
         </div>
       </div>
       <div class="torrent_details">
         ${torrent.percent} %
         ${this.config.hide_ratio ? '' : ` - ${translations[this.hass.config.language]?.ratio || translations['en'].ratio}: ${torrent.ratio.toFixed(2)}`}
+        ${this.config.hide_eta || !torrent.eta || torrent.eta < 0 ? '' : ` - ${translations[this.hass.config.language]?.eta || translations['en'].eta}: ${this._formatEta(torrent.eta)}`}
       </div>
       <div class="torrent-buttons">
         ${this.renderTorrentButton(torrent)}


### PR DESCRIPTION
I added ETA for full and compact
download and upload color can be customized
seeding can set to hide, it is nessesary when you only want to see downloading/uploading torrents but under type active they also show all seedings.